### PR TITLE
settings whitelist: user id bug fix

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -379,7 +379,7 @@
 
     function fillNameSelect($this, defaultUser) {
         for (var u in users) {
-            var value = users[u].common.name;
+            var value = users[u]._id.replace('system.user.', '');
             var valueText = users[u].common.name[0].toUpperCase() + users[u].common.name.substring(1);
             addOptionIfAbsent($this, value, valueText, defaultUser);
         }

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -518,7 +518,7 @@
     function fillNameSelect($this, defaultUser) {
         for (var u in users) {
             if (!users.hasOwnProperty(u)) continue;
-            var value = users[u].common.name;
+            var value = users[u]._id.replace('system.user.', '');
             var valueText = users[u].common.name[0].toUpperCase() + users[u].common.name.substring(1);
             addOptionIfAbsent($this, value, valueText, defaultUser);
         }


### PR DESCRIPTION
In der Einstellung des Adapters wird nicht die userId sonder der userName im native gespeichert.

Beispiel: UserName `Ich bein ein User`, UserId: `ich_bin_ein_user`

![web01](https://user-images.githubusercontent.com/6370451/78941936-ef903d00-7ab8-11ea-9168-b9401021f9ff.png)

![web02](https://user-images.githubusercontent.com/6370451/78941944-f28b2d80-7ab8-11ea-8645-03fa3b6b9b3c.png)

Dieser PR behebt das Problem und schreibt ins nativ die userId.
Allerdings hab ich das mit `.replace('system.user.', '')` gelöst, evtl. gibt es da ja bereits ein entsprechende Funktion?
