### PR TITLE
Issue/281/depricate lets encrypt

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -179,6 +179,7 @@
     "certPublic": "",
     "certPrivate": "",
     "certChained": "",
+    "certificateCollectionId": "",
     "addUserName": false,
     "forceWebSockets": false,
     "compatibilityV2": true,

--- a/io-package.json
+++ b/io-package.json
@@ -179,7 +179,6 @@
     "certPublic": "",
     "certPrivate": "",
     "certChained": "",
-    "certificateCollectionId": "",
     "addUserName": false,
     "forceWebSockets": false,
     "compatibilityV2": true,


### PR DESCRIPTION
This assumes 'old' config if `settings.certPublic && settings.certPrivate`

The config settings page needs updating to allow 'settings.secure' to be turned on with the above certificate fields to be left blank. In that case, the server will use the new module which will try and automagically match a certificate collection to use.

... which means that the config settings should not allow 'settings.secure' to be turned on with blank certificate fields unless there is at least one certificate collection available (ie. ACME has already been setup and run).

Maybe someone who knows this config method better than I do could suggest how best to handle this? *subtleHint*