### PR TITLE
node 16 required due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "https://github.com/ioBroker/ioBroker.web"
   },
+  "engines": {
+    "node": ">= 16"
+  },
   "dependencies": {
     "@iobroker/webserver": "^0.3.6",
     "@iobroker/adapter-core": "^3.0.3",


### PR DESCRIPTION
Adapter core 3.x.x required node 16 or newer