### PR TITLE
Extensions may block the web instance

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,6 +46,6 @@
         "no-trailing-spaces": "error"
     },
     "parserOptions": {
-        "ecmaVersion": 2019
+        "ecmaVersion": 2021
     }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.dev-server
 .idea
 tmp
 admin/i18n/*/flat.txt

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014-2023 bluefox <dogafox@gmail.com>
+Copyright (c) 2014-2024 bluefox <dogafox@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ the path could be provided here (e.g. `/vis/`) so this path will be opened autom
 -->
 
 ## Changelog
+### **WORK IN PROGRESS**
+* (klein0r) Extensions may block the web instance
+* (klein0r) Fixed directory listing
+
 ### 6.2.3 (2023-12-18)
 * (foxriver76) update websocket library to increase maximum file size from 100 MB to 500 MB
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ the path could be provided here (e.g. `/vis/`) so this path will be opened autom
 ## License
 The MIT License (MIT)
 
-Copyright (c) 2014-2023 Bluefox <dogafox@gmail.com>
+Copyright (c) 2014-2024 Bluefox <dogafox@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/main.js
+++ b/main.js
@@ -262,7 +262,7 @@ function startAdapter(options) {
             }
         },
         unload: callback => {
-            checkTimeout && clearTimeout(checkTimeout);
+            checkTimeout && adapter.clearTimeout(checkTimeout);
             checkTimeout = null;
 
             try {
@@ -290,7 +290,7 @@ function startAdapter(options) {
 
                 let timeout;
                 if (promises.length) {
-                    timeout = setTimeout(() => {
+                    timeout = adapter.setTimeout(() => {
                         timeout = null;
                         adapter && adapter.log && adapter.log.warn(`Timeout by termination of web-extensions!`);
                         webServer && webServer.settings && adapter && adapter.log && adapter.log.debug(`terminating http${webServer.settings.secure ? 's' : ''} server on port ${webServer.settings.port}`);
@@ -305,7 +305,7 @@ function startAdapter(options) {
                     .catch(e => adapter && adapter.log && adapter.log.error(`Cannot unload web extensions: ${e}`))
                     .then(() => {
                         if (!promises.length || timeout) {
-                            clearTimeout(timeout);
+                            adapter.clearTimeout(timeout);
                             timeout = null;
                             webServer && webServer.settings && adapter && adapter.log && adapter.log.debug(`terminating http${webServer.settings.secure ? 's' : ''} server on port ${webServer.settings.port}`);
                             webServer && webServer.io && webServer.io.close();
@@ -1590,7 +1590,7 @@ async function initWebServer(settings) {
                 adapter.setState('info.connection', true, true);
 
                 if (!settings.doNotCheckPublicIP && !settings.auth) {
-                    checkTimeout = setTimeout(async () => {
+                    checkTimeout = adapter.setTimeout(async () => {
                         checkTimeout = null;
                         try {
                             await IoBWebServer.checkPublicIP(settings.port, 'ioBroker.web', '/iobroker_check.html');

--- a/main.js
+++ b/main.js
@@ -1838,30 +1838,28 @@ async function initWebServer(settings) {
                                 },
                                 (err, buffer, mimeType) => {
                                     if (adapter.config.showFolderIndex && err && err.toString() === 'Error: Not exists' && req.url.endsWith('/')) {
-                                        url = url.replace(/\/index.html$/, '');
+                                        url = url.replace(/\/?index.html$/, '');
                                         // show folder index
+
+                                        const path = webByVersion[id] && versionPrefix ? url.substring(versionPrefix.length + 1) : url;
                                         return adapter.readDir(
                                             id,
-                                            webByVersion[id] && versionPrefix ? url.substring(versionPrefix.length + 1) : url,
+                                            path,
                                             {
                                                 user: req.user ? `system.user.${req.user}` : settings.defaultUser
                                             },
                                             (err, files) => {
+                                                adapter.log.debug(`readDir ${id} (${path}): ${JSON.stringify(files)}`);
+
                                                 res.set('Cache-Control', `public, max-age=${adapter.config.staticAssetCacheMaxAge}`);
                                                 res.set('Content-Type', 'text/html; charset=utf-8');
                                                 const text = [
                                                     '<html>',
                                                     '<head><title>Directory</title>',
-                                                    `<style>
-    body {
-        font-family: Arial, sans-serif;
-    }
-    td {
-        padding: 5px;
-    }
-</style>`,
+                                                    `<style>body { font-family: Arial, sans-serif; } td { padding: 5px; }</style>`,
                                                     `</head><body><h3>Directory ${req.url}</h3><table>`
                                                 ];
+
                                                 if (url !== '/') {
                                                     const parts = url.split('/');
                                                     parts.pop();
@@ -1871,11 +1869,9 @@ async function initWebServer(settings) {
                                                 files.sort((a, b) => {
                                                     if (a.isDir && b.isDir) {
                                                         return a.file.localeCompare(b.file);
-                                                    }
-                                                    if (a.isDir) {
+                                                    } else if (a.isDir) {
                                                         return -1;
-                                                    }
-                                                    if (b.isDir) {
+                                                    } else if (b.isDir) {
                                                         return 1;
                                                     }
 


### PR DESCRIPTION
When callback of `waitForReady` is never called, the promises won't be resolved and the web adapter waits forever. Added a timeout of 5 seconds.